### PR TITLE
Make gh action optional

### DIFF
--- a/.github/workflows/prevent-deadlock.yml
+++ b/.github/workflows/prevent-deadlock.yml
@@ -12,5 +12,6 @@ jobs:
           fetch-depth: 0
       - name: Look for migrations
         uses: GradedJestRisk/prevent-database-migration-deadlock@v1.3
+        continue-on-error: true
         with:
           migration-directory: 'migrations'


### PR DESCRIPTION
The prevent-action deadlock should fail, but merge should not considered as breaking change