### PR TITLE
Add delay to check autorebase

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
-name: merge if all checks passed
+name: merge - rebasing branch if out of date
+
 on:
   pull_request:
     types:
@@ -6,16 +7,20 @@ on:
   check_suite:
     types:
       - completed
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@master"
+        uses: "pascalgn/automerge-action@v0.14.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.EXTERNAL_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"
           MERGE_FORKS: "false"
+          MERGE_RETRIES: 1
+          MERGE_RETRY_SLEEP : 1000
+          LOG: "TRACE"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run wait-a-minute && npm run test:fake-success",
-    "wait-a-minute": "wait 1m",
+    "wait-a-minute": "sleep 1m",
     "test:fake-success": "exit 0",
     "test:fake-failure": "exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:fake-success",
+    "test": "npm run wait-a-minute && npm run test:fake-success",
+    "wait-a-minute": "wait 1m",
     "test:fake-success": "exit 0",
     "test:fake-failure": "exit 1"
   },


### PR DESCRIPTION
If checks triggered by autorebase make autorebase timeout, the `check_suite: completed` should trigger another workflow, see https://github.com/pascalgn/automerge-action/issues/170