### PR TITLE
Add feature 2

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.14.3"
         env:
-          GITHUB_TOKEN: "${{ github.token }}"
+          GITHUB_TOKEN: "${{ secrets.EXTERNAL_GITHUB_TOKEN }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"

--- a/feature/2.js
+++ b/feature/2.js
@@ -1,0 +1,1 @@
+console.log('feature 2')


### PR DESCRIPTION
## Problem
test #13 

## Solution
It's not working because we use the repository'own secret
See https://github.community/t/triggering-a-new-workflow-from-another-workflow/16250

The required checks are not run, hence PR will never be mergeable, unless manually repushed , which is what we want to avoid with auto-rebase

`checkout-test Expected — Waiting for status to be reported`